### PR TITLE
feat: extract client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,7 +252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -287,9 +298,12 @@ dependencies = [
 name = "dagger-core"
 version = "0.2.8"
 dependencies = [
+ "async-trait",
+ "base64",
  "dirs",
  "eyre",
  "flate2",
+ "gql_client",
  "graphql-introspection-query",
  "graphql_client",
  "hex",
@@ -310,13 +324,11 @@ dependencies = [
 name = "dagger-sdk"
 version = "0.2.19"
 dependencies = [
- "base64",
  "dagger-core",
  "derive_builder",
  "eyre",
  "futures",
  "genco",
- "gql_client",
  "pretty_assertions",
  "rand",
  "serde",
@@ -348,7 +360,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -359,7 +371,7 @@ checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -380,7 +392,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -390,7 +402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -593,7 +605,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -645,7 +657,7 @@ checksum = "c85fd34848b1f708e6344a4af6f7bfc05172ae20ce4b35c8e417efffb4f306aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -732,7 +744,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -743,7 +755,7 @@ checksum = "d52fc9cde811f44b15ec0692b31e56a3067f6f431c5ace712f286e47c1dacc98"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1134,7 +1146,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1477,7 +1489,7 @@ checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1575,6 +1587,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff13bb1732bccfe3b246f3fdb09edfd51c01d6f5299b7ccd9457c2e4e37774"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +1647,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1680,7 +1703,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1734,7 +1757,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1806,7 +1829,7 @@ checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
  "lazy_static",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1929,7 +1952,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -1963,7 +1986,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/dagger-codegen/src/rust/functions.rs
+++ b/crates/dagger-codegen/src/rust/functions.rs
@@ -247,7 +247,7 @@ fn render_execution(funcs: &CommonFunctions, field: &FullTypeFields) -> rust::To
             return $(output_type) {
                 proc: self.proc.clone(),
                 selection: query,
-                conn: self.conn.clone(),
+                graphql_client: self.graphql_client.clone(),
             }
         };
     }
@@ -273,7 +273,7 @@ fn render_execution(funcs: &CommonFunctions, field: &FullTypeFields) -> rust::To
             return vec![$(output_type) {
                 proc: self.proc.clone(),
                 selection: query,
-                conn: self.conn.clone(),
+                graphql_client: self.graphql_client.clone(),
             }]
         };
     }

--- a/crates/dagger-codegen/src/rust/functions.rs
+++ b/crates/dagger-codegen/src/rust/functions.rs
@@ -278,10 +278,8 @@ fn render_execution(funcs: &CommonFunctions, field: &FullTypeFields) -> rust::To
         };
     }
 
-    let graphql_client = rust::import("crate::client", "graphql_client");
-
     quote! {
-        query.execute(&$graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 

--- a/crates/dagger-codegen/src/rust/templates/object_tmpl.rs
+++ b/crates/dagger-codegen/src/rust/templates/object_tmpl.rs
@@ -12,15 +12,15 @@ use crate::utility::OptionExt;
 pub fn render_object(funcs: &CommonFunctions, t: &FullType) -> eyre::Result<rust::Tokens> {
     let selection = rust::import("crate::querybuilder", "Selection");
     let child = rust::import("tokio::process", "Child");
-    let conn = rust::import("dagger_core::connect_params", "ConnectParams");
+    let graphql_client = rust::import("dagger_core::graphql_client", "DynGraphQLClient");
     let arc = rust::import("std::sync", "Arc");
 
     Ok(quote! {
-        #[derive(Debug, Clone)]
+        #[derive(Clone)]
         pub struct $(t.name.pipe(|s| format_name(s))) {
             pub proc: $arc<$child>,
             pub selection: $selection,
-            pub conn: $conn,
+            pub graphql_client: $graphql_client
         }
 
         $(t.fields.pipe(|f| render_optional_args(funcs, f)))

--- a/crates/dagger-core/Cargo.toml
+++ b/crates/dagger-core/Cargo.toml
@@ -17,6 +17,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+base64 = "0.21.0"
+gql_client = "1.0.7"
 dirs = "4.0.0"
 flate2 = { version = "1.0.25", features = ["zlib"] }
 graphql-introspection-query = "0.2.0"
@@ -28,3 +30,4 @@ reqwest = { version = "0.11.14", features = ["stream", "deflate"] }
 sha2 = "0.10.6"
 tar = "0.4.38"
 tempfile = "3.3.0"
+async-trait = "0.1.67"

--- a/crates/dagger-core/src/graphql_client.rs
+++ b/crates/dagger-core/src/graphql_client.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use base64::engine::general_purpose;
+use base64::Engine;
+use gql_client::ClientConfig;
+use serde::Deserialize;
+
+use crate::connect_params::ConnectParams;
+
+pub trait GraphQLClient {
+    fn query<K>(&self, query: String) -> Pin<Box<dyn Future<Output = eyre::Result<Option<K>>>>>
+    where
+        K: for<'de> Deserialize<'de>;
+}
+
+pub type DynGraphQLClient = Arc<dyn GraphQLClient + Send + Sync>;
+
+#[derive(Debug)]
+pub struct DefaultGraphQLClient {
+    client: gql_client::Client,
+}
+
+impl DefaultGraphQLClient {
+    pub fn new(conn: &ConnectParams) -> Self {
+        let token = general_purpose::URL_SAFE.encode(format!("{}:", conn.session_token));
+
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), format!("Basic {}", token));
+
+        Self {
+            client: gql_client::Client::new_with_config(ClientConfig {
+                endpoint: conn.url(),
+                timeout: Some(1000),
+                headers: Some(headers),
+                proxy: None,
+            }),
+        }
+    }
+}
+
+impl GraphQLClient for DefaultGraphQLClient {
+    fn query<K>(&self, query: String) -> Pin<Box<dyn Future<Output = eyre::Result<Option<K>>>>>
+    where
+        Self: Sized,
+        K: for<'de> Deserialize<'de>,
+    {
+        let res = self.client.query::<K>(&query);
+
+        return Box::pin(res);
+    }
+}

--- a/crates/dagger-core/src/lib.rs
+++ b/crates/dagger-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod connect_params;
 pub mod downloader;
 pub mod engine;
+pub mod graphql_client;
 pub mod introspection;
 pub mod logger;
 pub mod schema;

--- a/crates/dagger-sdk/Cargo.toml
+++ b/crates/dagger-sdk/Cargo.toml
@@ -20,9 +20,7 @@ serde_json = { workspace = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
-base64 = "0.21.0"
 futures = "0.3.27"
-gql_client = "1.0.7"
 derive_builder = "0.12.0"
 
 [dev-dependencies]

--- a/crates/dagger-sdk/src/client.rs
+++ b/crates/dagger-sdk/src/client.rs
@@ -1,12 +1,8 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use base64::engine::general_purpose;
-use base64::Engine;
-use gql_client::ClientConfig;
+use dagger_core::graphql_client::DefaultGraphQLClient;
 
 use dagger_core::config::Config;
-use dagger_core::connect_params::ConnectParams;
 use dagger_core::engine::Engine as DaggerEngine;
 
 use crate::gen::Query;
@@ -25,24 +21,10 @@ pub async fn connect_opts(cfg: Config) -> eyre::Result<DaggerConn> {
     let (conn, proc) = DaggerEngine::new().start(&cfg).await?;
 
     Ok(Arc::new(Query {
-        conn,
         proc: Arc::new(proc),
         selection: query(),
+        graphql_client: Arc::new(DefaultGraphQLClient::new(&conn)),
     }))
-}
-
-pub fn graphql_client(conn: &ConnectParams) -> gql_client::Client {
-    let token = general_purpose::URL_SAFE.encode(format!("{}:", conn.session_token));
-
-    let mut headers = HashMap::new();
-    headers.insert("Authorization".to_string(), format!("Basic {}", token));
-
-    gql_client::Client::new_with_config(ClientConfig {
-        endpoint: conn.url(),
-        timeout: Some(1000),
-        headers: Some(headers),
-        proxy: None,
-    })
 }
 
 // Conn will automatically close on drop of proc

--- a/crates/dagger-sdk/src/gen.rs
+++ b/crates/dagger-sdk/src/gen.rs
@@ -1,6 +1,7 @@
 use crate::client::graphql_client;
 use crate::querybuilder::Selection;
 use dagger_core::connect_params::ConnectParams;
+use dagger_core::graphql_client::DynGraphQLClient;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -114,11 +115,12 @@ pub struct PipelineLabel {
     pub name: String,
     pub value: String,
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CacheVolume {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl CacheVolume {
@@ -128,11 +130,12 @@ impl CacheVolume {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Container {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
@@ -296,6 +299,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -323,6 +327,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves default arguments for future commands.
@@ -346,6 +351,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves an endpoint that clients can use to reach this container.
@@ -408,6 +414,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         }];
     }
     /// Retrieves this container after executing the specified command inside it.
@@ -422,6 +429,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -456,6 +464,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Exit code of the last executed command. Zero means success.
@@ -514,6 +523,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         }];
     }
     /// Retrieves a file at the given path.
@@ -531,6 +541,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Initializes this container from a pulled base image.
@@ -549,6 +560,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container's root filesystem. Mounts are not included.
@@ -559,6 +571,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves a hostname which can be used by clients to reach this container.
@@ -596,6 +609,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         }];
     }
     /// Retrieves the list of paths where a directory is mounted.
@@ -619,6 +633,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -647,6 +662,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// The platform this container executes and publishes as.
@@ -705,6 +721,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// The error stream of the last executed command.
@@ -739,6 +756,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -758,6 +776,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a directory written at the given path.
@@ -777,6 +796,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -808,6 +828,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container but with a different command entrypoint.
@@ -827,6 +848,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus the given environment variable.
@@ -849,6 +871,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container after executing the specified command inside it.
@@ -869,6 +892,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -912,6 +936,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Expose a network port.
@@ -933,6 +958,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -965,6 +991,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Initializes this container from this DirectoryID.
@@ -977,6 +1004,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus the contents of the given file copied to the given path.
@@ -996,6 +1024,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1024,6 +1053,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus the given label.
@@ -1042,6 +1072,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a cache volume mounted at the given path.
@@ -1061,6 +1092,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1092,6 +1124,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a directory mounted at the given path.
@@ -1114,6 +1147,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a file mounted at the given path.
@@ -1132,6 +1166,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a secret mounted into a file at the given path.
@@ -1150,6 +1185,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a temporary directory mounted at the given path.
@@ -1166,6 +1202,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a new file written at the given path.
@@ -1183,6 +1220,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1211,6 +1249,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container with a registry authentication for a given address.
@@ -1237,6 +1276,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Initializes this container from this DirectoryID.
@@ -1249,6 +1289,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus an env variable containing the given secret.
@@ -1267,6 +1308,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Establish a runtime dependency on a service. The service will be started automatically when needed and detached when it is no longer needed.
@@ -1292,6 +1334,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
@@ -1310,6 +1353,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container with a different command user.
@@ -1326,6 +1370,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container with a different working directory.
@@ -1342,6 +1387,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container minus the given environment variable.
@@ -1358,6 +1404,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Unexpose a previously exposed port.
@@ -1376,6 +1423,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1402,6 +1450,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container minus the given environment label.
@@ -1418,6 +1467,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container after unmounting everything at the given path.
@@ -1434,6 +1484,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container without the registry authentication of a given address.
@@ -1451,6 +1502,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this container with a previously added Unix socket removed.
@@ -1467,6 +1519,7 @@ impl Container {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves the working directory for all commands.
@@ -1476,11 +1529,12 @@ impl Container {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Directory {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
@@ -1560,6 +1614,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves a directory at the given path.
@@ -1576,6 +1631,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Builds a new Docker container from this directory.
@@ -1590,6 +1646,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1618,6 +1675,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Returns a list of files and directories at the given path.
@@ -1674,6 +1732,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// The content-addressed identifier of the directory.
@@ -1692,6 +1751,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Creates a named sub-pipeline
@@ -1709,6 +1769,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1737,6 +1798,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this directory plus a directory written at the given path.
@@ -1756,6 +1818,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1787,6 +1850,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this directory plus the contents of the given file copied to the given path.
@@ -1806,6 +1870,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1834,6 +1899,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this directory plus a new directory created at the given path.
@@ -1851,6 +1917,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1876,6 +1943,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this directory plus a new file written at the given path.
@@ -1895,6 +1963,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -1923,6 +1992,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this directory with all file/dir timestamps set to the given time.
@@ -1941,6 +2011,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this directory with the directory at the given path removed.
@@ -1957,6 +2028,7 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves this directory with the file at the given path removed.
@@ -1973,14 +2045,16 @@ impl Directory {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct EnvVariable {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl EnvVariable {
@@ -1997,11 +2071,12 @@ impl EnvVariable {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct File {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl File {
@@ -2037,6 +2112,7 @@ impl File {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Gets the size of the file, in bytes.
@@ -2061,14 +2137,16 @@ impl File {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GitRef {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
@@ -2098,6 +2176,7 @@ impl GitRef {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2120,14 +2199,16 @@ impl GitRef {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct GitRepository {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl GitRepository {
@@ -2145,6 +2226,7 @@ impl GitRepository {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Lists of branches on the repository.
@@ -2167,6 +2249,7 @@ impl GitRepository {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Returns details on one tag.
@@ -2183,6 +2266,7 @@ impl GitRepository {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Lists of tags on the repository.
@@ -2192,11 +2276,12 @@ impl GitRepository {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Host {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
@@ -2234,6 +2319,7 @@ impl Host {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2262,6 +2348,7 @@ impl Host {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Accesses an environment variable on the host.
@@ -2278,6 +2365,7 @@ impl Host {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Accesses a Unix socket on the host.
@@ -2294,6 +2382,7 @@ impl Host {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Retrieves the current working directory on the host.
@@ -2308,6 +2397,7 @@ impl Host {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2330,14 +2420,16 @@ impl Host {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HostVariable {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl HostVariable {
@@ -2349,6 +2441,7 @@ impl HostVariable {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// The value of this variable.
@@ -2358,11 +2451,12 @@ impl HostVariable {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Label {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Label {
@@ -2379,11 +2473,12 @@ impl Label {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Port {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Port {
@@ -2406,11 +2501,12 @@ impl Port {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Project {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Project {
@@ -2422,6 +2518,7 @@ impl Project {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         }];
     }
     /// Code files generated by the SDKs in the project
@@ -2432,6 +2529,7 @@ impl Project {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// install the project's schema
@@ -2459,11 +2557,11 @@ impl Project {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Query {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
@@ -2523,6 +2621,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Loads a container from ID.
@@ -2540,6 +2639,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2565,6 +2665,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// The default platform of the builder.
@@ -2585,6 +2686,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2604,6 +2706,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Loads a file by ID.
@@ -2616,6 +2719,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Queries a git repository.
@@ -2635,6 +2739,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2661,6 +2766,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Queries the host environment.
@@ -2671,6 +2777,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Returns a file containing an http remote url content.
@@ -2688,6 +2795,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2709,6 +2817,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Creates a named sub-pipeline.
@@ -2726,6 +2835,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2750,6 +2860,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Look up a project by name
@@ -2762,6 +2873,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Loads a secret from its ID.
@@ -2774,6 +2886,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
     /// Loads a socket by its ID.
@@ -2788,6 +2901,7 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 
@@ -2807,14 +2921,16 @@ impl Query {
             proc: self.proc.clone(),
             selection: query,
             conn: self.conn.clone(),
+            graphql_client: self.graphql_client.clone(),
         };
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Secret {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Secret {
@@ -2831,11 +2947,12 @@ impl Secret {
         query.execute(&graphql_client(&self.conn)).await
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Socket {
     pub proc: Arc<Child>,
     pub selection: Selection,
     pub conn: ConnectParams,
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Socket {

--- a/crates/dagger-sdk/src/gen.rs
+++ b/crates/dagger-sdk/src/gen.rs
@@ -1,6 +1,4 @@
-use crate::client::graphql_client;
 use crate::querybuilder::Selection;
-use dagger_core::connect_params::ConnectParams;
 use dagger_core::graphql_client::DynGraphQLClient;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
@@ -119,7 +117,6 @@ pub struct PipelineLabel {
 pub struct CacheVolume {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -127,14 +124,13 @@ impl CacheVolume {
     pub async fn id(&self) -> eyre::Result<CacheId> {
         let query = self.selection.select("id");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct Container {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -298,7 +294,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -326,7 +321,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -334,7 +328,7 @@ impl Container {
     pub async fn default_args(&self) -> eyre::Result<Vec<String>> {
         let query = self.selection.select("defaultArgs");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a directory at the given path.
     /// Mounts are included.
@@ -350,7 +344,6 @@ impl Container {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -365,7 +358,7 @@ impl Container {
     pub async fn endpoint(&self) -> eyre::Result<String> {
         let query = self.selection.select("endpoint");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 
     /// Retrieves an endpoint that clients can use to reach this container.
@@ -386,13 +379,13 @@ impl Container {
             query = query.arg("scheme", scheme);
         }
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves entrypoint to be prepended to the arguments of all commands.
     pub async fn entrypoint(&self) -> eyre::Result<Vec<String>> {
         let query = self.selection.select("entrypoint");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the value of the specified environment variable.
     ///
@@ -404,7 +397,7 @@ impl Container {
 
         query = query.arg("name", name.into());
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of environment variables passed to commands.
     pub fn env_variables(&self) -> Vec<EnvVariable> {
@@ -413,7 +406,6 @@ impl Container {
         return vec![EnvVariable {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         }];
     }
@@ -428,7 +420,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -463,7 +454,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -472,7 +462,7 @@ impl Container {
     pub async fn exit_code(&self) -> eyre::Result<isize> {
         let query = self.selection.select("exitCode");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.
     /// Return true on success.
@@ -488,7 +478,7 @@ impl Container {
 
         query = query.arg("path", path.into());
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 
     /// Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.
@@ -512,7 +502,7 @@ impl Container {
             query = query.arg("platformVariants", platform_variants);
         }
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of exposed ports.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
@@ -522,7 +512,6 @@ impl Container {
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         }];
     }
@@ -540,7 +529,6 @@ impl Container {
         return File {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -559,7 +547,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -570,7 +557,6 @@ impl Container {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -579,19 +565,19 @@ impl Container {
     pub async fn hostname(&self) -> eyre::Result<String> {
         let query = self.selection.select("hostname");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this container.
     pub async fn id(&self) -> eyre::Result<ContainerId> {
         let query = self.selection.select("id");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The unique image reference which can only be retrieved immediately after the 'Container.From' call.
     pub async fn image_ref(&self) -> eyre::Result<String> {
         let query = self.selection.select("imageRef");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the value of the specified label.
     pub async fn label(&self, name: impl Into<String>) -> eyre::Result<String> {
@@ -599,7 +585,7 @@ impl Container {
 
         query = query.arg("name", name.into());
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of labels passed to container.
     pub fn labels(&self) -> Vec<Label> {
@@ -608,7 +594,6 @@ impl Container {
         return vec![Label {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         }];
     }
@@ -616,7 +601,7 @@ impl Container {
     pub async fn mounts(&self) -> eyre::Result<Vec<String>> {
         let query = self.selection.select("mounts");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Creates a named sub-pipeline
     ///
@@ -632,7 +617,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -661,7 +645,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -669,7 +652,7 @@ impl Container {
     pub async fn platform(&self) -> eyre::Result<Platform> {
         let query = self.selection.select("platform");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
@@ -686,7 +669,7 @@ impl Container {
 
         query = query.arg("address", address.into());
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 
     /// Publishes this container as a new image to the specified address.
@@ -711,7 +694,7 @@ impl Container {
             query = query.arg("platformVariants", platform_variants);
         }
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this container's root filesystem. Mounts are not included.
     pub fn rootfs(&self) -> Directory {
@@ -720,7 +703,6 @@ impl Container {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -729,20 +711,20 @@ impl Container {
     pub async fn stderr(&self) -> eyre::Result<String> {
         let query = self.selection.select("stderr");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The output stream of the last executed command.
     /// Errors if no command has been executed.
     pub async fn stdout(&self) -> eyre::Result<String> {
         let query = self.selection.select("stdout");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the user to be set for all commands.
     pub async fn user(&self) -> eyre::Result<String> {
         let query = self.selection.select("user");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Configures default arguments for future commands.
     ///
@@ -755,7 +737,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -775,7 +756,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -795,7 +775,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -827,7 +806,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -847,7 +825,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -870,7 +847,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -891,7 +867,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -935,7 +910,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -957,7 +931,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -990,7 +963,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1003,7 +975,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1023,7 +994,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1052,7 +1022,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1071,7 +1040,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1091,7 +1059,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1123,7 +1090,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1146,7 +1112,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1165,7 +1130,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1184,7 +1148,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1201,7 +1164,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1219,7 +1181,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1248,7 +1209,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1275,7 +1235,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1288,7 +1247,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1307,7 +1265,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1333,7 +1290,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1352,7 +1308,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1369,7 +1324,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1386,7 +1340,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1403,7 +1356,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1422,7 +1374,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1449,7 +1400,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1466,7 +1416,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1483,7 +1432,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1501,7 +1449,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1518,7 +1465,6 @@ impl Container {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1526,14 +1472,13 @@ impl Container {
     pub async fn workdir(&self) -> eyre::Result<String> {
         let query = self.selection.select("workdir");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct Directory {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -1613,7 +1558,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1630,7 +1574,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1645,7 +1588,6 @@ impl Directory {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1674,7 +1616,6 @@ impl Directory {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1686,7 +1627,7 @@ impl Directory {
     pub async fn entries(&self) -> eyre::Result<Vec<String>> {
         let query = self.selection.select("entries");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 
     /// Returns a list of files and directories at the given path.
@@ -1704,7 +1645,7 @@ impl Directory {
             query = query.arg("path", path);
         }
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Writes the contents of the directory to a path on the host.
     ///
@@ -1716,7 +1657,7 @@ impl Directory {
 
         query = query.arg("path", path.into());
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a file at the given path.
     ///
@@ -1731,7 +1672,6 @@ impl Directory {
         return File {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1739,7 +1679,7 @@ impl Directory {
     pub async fn id(&self) -> eyre::Result<DirectoryId> {
         let query = self.selection.select("id");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// load a project's metadata
     pub fn load_project(&self, config_path: impl Into<String>) -> Project {
@@ -1750,7 +1690,6 @@ impl Directory {
         return Project {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1768,7 +1707,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1797,7 +1735,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1817,7 +1754,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1849,7 +1785,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1869,7 +1804,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1898,7 +1832,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1916,7 +1849,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1942,7 +1874,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1962,7 +1893,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -1991,7 +1921,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2010,7 +1939,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2027,7 +1955,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2044,7 +1971,6 @@ impl Directory {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2053,7 +1979,6 @@ impl Directory {
 pub struct EnvVariable {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2062,20 +1987,19 @@ impl EnvVariable {
     pub async fn name(&self) -> eyre::Result<String> {
         let query = self.selection.select("name");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable value.
     pub async fn value(&self) -> eyre::Result<String> {
         let query = self.selection.select("value");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct File {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2084,7 +2008,7 @@ impl File {
     pub async fn contents(&self) -> eyre::Result<String> {
         let query = self.selection.select("contents");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Writes the file to a file path on the host.
     ///
@@ -2096,13 +2020,13 @@ impl File {
 
         query = query.arg("path", path.into());
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the content-addressed identifier of the file.
     pub async fn id(&self) -> eyre::Result<FileId> {
         let query = self.selection.select("id");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a secret referencing the contents of this file.
     pub fn secret(&self) -> Secret {
@@ -2111,7 +2035,6 @@ impl File {
         return Secret {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2119,7 +2042,7 @@ impl File {
     pub async fn size(&self) -> eyre::Result<isize> {
         let query = self.selection.select("size");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this file with its created/modified timestamps set to the given time.
     ///
@@ -2136,7 +2059,6 @@ impl File {
         return File {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2145,7 +2067,6 @@ impl File {
 pub struct GitRef {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2162,7 +2083,7 @@ impl GitRef {
     pub async fn digest(&self) -> eyre::Result<String> {
         let query = self.selection.select("digest");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The filesystem tree at this ref.
     ///
@@ -2175,7 +2096,6 @@ impl GitRef {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2198,7 +2118,6 @@ impl GitRef {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2207,7 +2126,6 @@ impl GitRef {
 pub struct GitRepository {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2225,7 +2143,6 @@ impl GitRepository {
         return GitRef {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2233,7 +2150,7 @@ impl GitRepository {
     pub async fn branches(&self) -> eyre::Result<Vec<String>> {
         let query = self.selection.select("branches");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Returns details on one commit.
     ///
@@ -2248,7 +2165,6 @@ impl GitRepository {
         return GitRef {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2265,7 +2181,6 @@ impl GitRepository {
         return GitRef {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2273,14 +2188,13 @@ impl GitRepository {
     pub async fn tags(&self) -> eyre::Result<Vec<String>> {
         let query = self.selection.select("tags");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct Host {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2318,7 +2232,6 @@ impl Host {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2347,7 +2260,6 @@ impl Host {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2364,7 +2276,6 @@ impl Host {
         return HostVariable {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2381,7 +2292,6 @@ impl Host {
         return Socket {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2396,7 +2306,6 @@ impl Host {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2419,7 +2328,6 @@ impl Host {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2428,7 +2336,6 @@ impl Host {
 pub struct HostVariable {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2440,7 +2347,6 @@ impl HostVariable {
         return Secret {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2448,14 +2354,13 @@ impl HostVariable {
     pub async fn value(&self) -> eyre::Result<String> {
         let query = self.selection.select("value");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct Label {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2464,20 +2369,19 @@ impl Label {
     pub async fn name(&self) -> eyre::Result<String> {
         let query = self.selection.select("name");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The label value.
     pub async fn value(&self) -> eyre::Result<String> {
         let query = self.selection.select("value");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct Port {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2486,26 +2390,25 @@ impl Port {
     pub async fn description(&self) -> eyre::Result<String> {
         let query = self.selection.select("description");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The port number.
     pub async fn port(&self) -> eyre::Result<isize> {
         let query = self.selection.select("port");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The transport layer network protocol.
     pub async fn protocol(&self) -> eyre::Result<NetworkProtocol> {
         let query = self.selection.select("protocol");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct Project {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2517,7 +2420,6 @@ impl Project {
         return vec![Project {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         }];
     }
@@ -2528,7 +2430,6 @@ impl Project {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2536,25 +2437,25 @@ impl Project {
     pub async fn install(&self) -> eyre::Result<bool> {
         let query = self.selection.select("install");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// name of the project
     pub async fn name(&self) -> eyre::Result<String> {
         let query = self.selection.select("name");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// schema provided by the project
     pub async fn schema(&self) -> eyre::Result<String> {
         let query = self.selection.select("schema");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// sdk used to generate code for and/or execute this project
     pub async fn sdk(&self) -> eyre::Result<String> {
         let query = self.selection.select("sdk");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
@@ -2620,7 +2521,6 @@ impl Query {
         return CacheVolume {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2638,7 +2538,6 @@ impl Query {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2664,7 +2563,6 @@ impl Query {
         return Container {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2672,7 +2570,7 @@ impl Query {
     pub async fn default_platform(&self) -> eyre::Result<Platform> {
         let query = self.selection.select("defaultPlatform");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// Load a directory by ID. No argument produces an empty directory.
     ///
@@ -2685,7 +2583,6 @@ impl Query {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2705,7 +2602,6 @@ impl Query {
         return Directory {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2718,7 +2614,6 @@ impl Query {
         return File {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2738,7 +2633,6 @@ impl Query {
         return GitRepository {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2765,7 +2659,6 @@ impl Query {
         return GitRepository {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2776,7 +2669,6 @@ impl Query {
         return Host {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2794,7 +2686,6 @@ impl Query {
         return File {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2816,7 +2707,6 @@ impl Query {
         return File {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2834,7 +2724,6 @@ impl Query {
         return Query {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2859,7 +2748,6 @@ impl Query {
         return Query {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2872,7 +2760,6 @@ impl Query {
         return Project {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2885,7 +2772,6 @@ impl Query {
         return Secret {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2900,7 +2786,6 @@ impl Query {
         return Socket {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2920,7 +2805,6 @@ impl Query {
         return Socket {
             proc: self.proc.clone(),
             selection: query,
-            conn: self.conn.clone(),
             graphql_client: self.graphql_client.clone(),
         };
     }
@@ -2929,7 +2813,6 @@ impl Query {
 pub struct Secret {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2938,20 +2821,19 @@ impl Secret {
     pub async fn id(&self) -> eyre::Result<SecretId> {
         let query = self.selection.select("id");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
     /// The value of this secret.
     pub async fn plaintext(&self) -> eyre::Result<String> {
         let query = self.selection.select("plaintext");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Clone)]
 pub struct Socket {
     pub proc: Arc<Child>,
     pub selection: Selection,
-    pub conn: ConnectParams,
     pub graphql_client: DynGraphQLClient,
 }
 
@@ -2960,7 +2842,7 @@ impl Socket {
     pub async fn id(&self) -> eyre::Result<SocketId> {
         let query = self.selection.select("id");
 
-        query.execute(&graphql_client(&self.conn)).await
+        query.execute(self.graphql_client.clone()).await
     }
 }
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]

--- a/crates/dagger-sdk/src/querybuilder.rs
+++ b/crates/dagger-sdk/src/querybuilder.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, ops::Add, sync::Arc};
 
+use dagger_core::graphql_client::DynGraphQLClient;
 use eyre::Context;
 use serde::{Deserialize, Serialize};
 
@@ -116,7 +117,7 @@ impl Selection {
         Ok(fields.join("{") + &"}".repeat(fields.len() - 1))
     }
 
-    pub async fn execute<D>(&self, gql_client: &gql_client::Client) -> eyre::Result<D>
+    pub async fn execute<D>(&self, gql_client: DynGraphQLClient) -> eyre::Result<D>
     where
         D: for<'de> Deserialize<'de>,
     {


### PR DESCRIPTION
This extracts the client (strategy pattern), this is so that it is will be possible to test the actual querier, without hitting / requiring the dagger-engine running.
