### PR TITLE
feat: add windows support

### DIFF
--- a/.github/workflows/ci-multiplatform.yml
+++ b/.github/workflows/ci-multiplatform.yml
@@ -117,7 +117,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          #- windows-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install packages (macOS)
@@ -125,8 +125,10 @@ jobs:
         run: |
           ci/scripts/macos-install-packages
       - name: Set up QEMU
+        if: matrix.os != 'windows-latest'
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
+        if: matrix.os != 'windows-latest'
         uses: docker/setup-buildx-action@v2.0.0
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
Adds support for windows (CI and sdk): #47. This means rust dagger sdk can now
be natively executed on windows, as opposed to just through WSL2
